### PR TITLE
Backlinks with Google's AJAX Search API

### DIFF
--- a/lib/page_rankr/backlinks/google.rb
+++ b/lib/page_rankr/backlinks/google.rb
@@ -1,15 +1,20 @@
 require 'cgi'
+require 'json'
 
 module PageRankr
   class Backlinks < Tracker
     class Google < Backlink
-      def url(site)
-        "http://www.google.com/search?q=link%3A%22#{CGI.escape(site)}%22"
+      
+      # overloaded to use Google's AJAX search API
+      # http://code.google.com/apis/ajaxsearch/documentation/
+      def initialize(site)
+        @backlinks = clean JSON.parse( open( url(site)).read )["responseData"]["cursor"]["estimatedResultCount"].to_s
       end
       
-      def xpath
-        "//div[@id='resultStats']/text()"
+      def url(site)
+        "http://ajax.googleapis.com/ajax/services/search/web?v=1.0&q=link%3A#{CGI.escape(site)}"
       end
+
     end
   end
 end


### PR DESCRIPTION
Hello Allen,

I really like your PageRankr gem. I am using it on a project to collect the page ranks and backlink counts for several sites. The ranks method works great, however I ran into some problems with the backlinks method. 

I was running a script that uses PageRankr to get the page ranks and backlinks of about 40 sites. About halfway through I started getting 503 errors. I think Google may have blocked my IP. I didn't realize the PageRankr was connecting directly to Google's search page. 

I've never been a fan of screen scraping, so I thought it would be better for the PageRankr to use Google's AJAX Search API instead. Let me know what you think.

-Dru
