### PR TITLE
Fixed alexa global wrong subdomains

### DIFF
--- a/lib/page_rankr/ranks/alexa_global.rb
+++ b/lib/page_rankr/ranks/alexa_global.rb
@@ -7,7 +7,7 @@ module PageRankr
       include Rank
       
       def xpath
-        "//popularity[contains(@url, '#{@site.to_s}')]/@text"
+         "//popularity[contains(@url, '#{@site.domain}')]/@text"
       end
       
       def request


### PR DESCRIPTION
This time, Alexa will only accept ranks if the ranked page is in the same subdomain as the requested one
