### PR TITLE
Don't enforce old typhoeus version

### DIFF
--- a/PageRankr.gemspec
+++ b/PageRankr.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "nokogiri",              ">= 1.4.1"
   s.add_runtime_dependency "json",                  ">= 1.4.6"
   s.add_runtime_dependency "public_suffix_service", "~> 0.9.0"
-  s.add_runtime_dependency "typhoeus",              "~> 0.2.1"
+  s.add_runtime_dependency "typhoeus",              ">= 0.2.1"
   s.add_runtime_dependency "jsonpath",              "~> 0.4.2"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Hello,

I just allowed newer version of typhoeus than 0.2.1, current is 0.3.2.

Regards,
Hans
