### PR TITLE
Fix google backlink fetching.

### DIFF
--- a/lib/page_rankr/backlinks/google.rb
+++ b/lib/page_rankr/backlinks/google.rb
@@ -14,7 +14,7 @@ module PageRankr
       end
 
       def xpath
-        "//div[@id='subform_ctrl']/div[2]/b[3]/text()"
+        "//div[@id='subform_ctrl']/div[2]/text()"
       end
     end
   end

--- a/lib/page_rankr/tracker.rb
+++ b/lib/page_rankr/tracker.rb
@@ -13,7 +13,7 @@ module PageRankr
     def initialize(site, options = {})
       @site = PageRankr::Site(site)
 
-      @options = {:method => method}
+      @options = {:method => method, :headers => {'User-Agent' => 'Page Rankr'}}
       @options[:params] = params if respond_to? :params
       @options.merge!(options)
       


### PR DESCRIPTION
Google requires user-agent header to be set in order to retrieve search results. Also the document structure has been changed, therefore xpath needed to be modified.
