### PR TITLE
Point Alexa US at correct data. 

### DIFF
--- a/PageRankr.gemspec
+++ b/PageRankr.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "nokogiri",              ">= 1.4.1"
   s.add_runtime_dependency "json",                  ">= 1.4.6"
-  s.add_runtime_dependency "public_suffix",         ">= 1.4.4"
+  s.add_runtime_dependency "public_suffix",         "~> 1.4.4"
   s.add_runtime_dependency "httparty",              ">= 0.9.0"
   s.add_runtime_dependency "jsonpath",              ">= 0.4.2"
 
@@ -30,4 +30,3 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_paths = ["lib"]
 end
-

--- a/lib/page_rankr/ranks/alexa_us.rb
+++ b/lib/page_rankr/ranks/alexa_us.rb
@@ -4,7 +4,7 @@ module PageRankr
   class Ranks
     class AlexaUs
       include Rank
-      
+
       def url
         "http://data.alexa.com/data"
       end
@@ -20,7 +20,7 @@ module PageRankr
       # to slocourts.net. Clearly something is wrong with how Alexa handles this case and so in the event this
       # happens we treat the results as if there were no results.
       def xpath
-        "//popularity[contains(@url, '#{tracked_url}')]/../reach/@rank"
+        "//popularity[contains(@url, '#{tracked_url}')]/../country[@code='US']/@rank"
       end
 
       def supported_components


### PR DESCRIPTION
It was reporting the unrelated reach rank.

Also, using google.com for the tests has the unfortunate consequence that all the rank figures from Alexa will be 1 because google.com is (currently) top for everything. It may be safer to use a domain which has differing ranks to make it easier to spot if the wrong data is being reported.