### PR TITLE
Remove version specification for public_suffix, add compat layer

### DIFF
--- a/PageRankr.gemspec
+++ b/PageRankr.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "nokogiri",              ">= 1.4.1"
   s.add_runtime_dependency "json",                  ">= 1.4.6"
-  s.add_runtime_dependency "public_suffix",         "~> 1.0"
+  s.add_runtime_dependency "public_suffix"
   s.add_runtime_dependency "httparty",              ">= 0.9.0"
   s.add_runtime_dependency "jsonpath",              ">= 0.4.2"
   s.add_runtime_dependency "addressable"

--- a/lib/page_rankr/site.rb
+++ b/lib/page_rankr/site.rb
@@ -9,9 +9,9 @@ module PageRankr
     def initialize(site)
       site = "http://#{site}" unless site =~ /:\/\//
       @uri = Addressable::URI.parse(site)
-      @domain = PublicSuffix.parse(@uri.host || "")
+      @domain = public_suffix_parse(@uri.host)
 
-      @domain.valid? or raise DomainInvalid, "The domain provided is invalid.1"
+      public_suffix_valid?(@domain) or raise DomainInvalid, "The domain provided is invalid.1"
     rescue PublicSuffix::DomainInvalid, Addressable::URI::InvalidURIError
       raise DomainInvalid, "The domain provided is invalid."
     end
@@ -69,6 +69,28 @@ module PageRankr
           fragment and "##{fragment}" or ""
         end
       end
+    end
+
+    private
+
+    def public_suffix_parse(host = '')
+      if public_suffix_verson_1?
+        PublicSuffix.parse(host)
+      else
+        PublicSuffix.parse(host, default_rule: nil)
+      end
+    end
+
+    def public_suffix_valid?(domain)
+      if public_suffix_verson_1?
+        domain.valid?
+      else
+        PublicSuffix.valid?(domain, default_rule: nil)
+      end
+    end
+
+    def public_suffix_verson_1?
+      defined?(PublicSuffix::Version) && PublicSuffix::Version::MAJOR == 1
     end
   end
 


### PR DESCRIPTION
I'm so sorry to do this to you, @blatyo, especially after reading your commit message here: https://github.com/trevorturk/page_rankr/commit/eea359c386e4ce9b7a76d0c18d96b405c5feceac

This is an attempt to solve the `public_suffix` versioning problem for good by:

1) removing the `public_suffix ` version specification entirely, and
2) adding a compatibility layer to accommodate `public_suffix` versions `1.x` and `2.x`

If you'd like, I'd be happy to join up as a maintainer. I don't think I'll be using the library much, but I'm happy to pitch in where I can. Thank you!